### PR TITLE
Configure immediate auto-merge on /lgtm label and CI completion

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: jpmcb/prow-github-actions@v2
+      - uses: jpmcb/prow-github-actions@v2.0.0
         with:
           prow-commands: '/lgtm /hold /cc /uncc /assign /unassign /kind /priority /area /milestone /close /reopen'
           github-token: '${{ secrets.GITHUB_TOKEN }}'
@@ -31,7 +31,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: jpmcb/prow-github-actions@v2
+      - uses: jpmcb/prow-github-actions@v2.0.0
         with:
           jobs: lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'
@@ -46,7 +46,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: jpmcb/prow-github-actions@v2
+      - uses: jpmcb/prow-github-actions@v2.0.0
         with:
           jobs: lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -1,154 +1,53 @@
-name: PR Auto Merge
+name: Prow Commands and Auto Merge
 
 on:
   issue_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
   status: {}
   check_suite:
     types: [completed]
 
 jobs:
-  handle-commands:
-    if: github.event.issue.pull_request && (contains(github.event.comment.body, '/lgtm') || contains(github.event.comment.body, '/approve'))
+  prow-commands:
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: jpmcb/prow-github-actions@v2
+        with:
+          prow-commands: '/lgtm /hold /cc /uncc /assign /unassign /kind /priority /area /milestone /close /reopen'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+  remove-lgtm-on-update:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write
       pull-requests: write
-      
     steps:
-    - name: Handle comment commands
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const comment = context.payload.comment.body.toLowerCase();
-          const commenter = context.payload.comment.user.login;
-          const prNumber = context.issue.number;
-          
-          // Check if user is a collaborator
-          const { data: collaborators } = await github.rest.repos.listCollaborators({
-            owner: context.repo.owner,
-            repo: context.repo.repo
-          });
-          
-          const isCollaborator = collaborators.some(c => c.login === commenter);
-          
-          if (!isCollaborator) {
-            console.log(`${commenter} is not a collaborator, ignoring command`);
-            return;
-          }
-          
-          const labelsToAdd = [];
-          
-          if (comment.includes('/lgtm')) {
-            labelsToAdd.push('lgtm');
-          }
-          
-          if (comment.includes('/approve')) {
-            labelsToAdd.push('approved');
-          }
-          
-          if (labelsToAdd.length > 0) {
-            // Create labels if they don't exist
-            for (const labelName of labelsToAdd) {
-              try {
-                await github.rest.issues.getLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: labelName
-                });
-              } catch (error) {
-                if (error.status === 404) {
-                  await github.rest.issues.createLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name: labelName,
-                    color: '0e8a16',
-                    description: `Added by ${labelName} command`
-                  });
-                }
-              }
-            }
-            
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              labels: labelsToAdd
-            });
-            
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: `Added labels: ${labelsToAdd.join(', ')} by @${commenter}`
-            });
-          }
-  
+      - uses: jpmcb/prow-github-actions@v2
+        with:
+          jobs: lgtm
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
   auto-merge:
+    if: >
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'lgtm') ||
+      github.event_name == 'status' ||
+      github.event_name == 'check_suite'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
-    - name: Auto merge PR
-      uses: actions/github-script@v7
-      with:
-        script: |
-          // Get all open PRs with both labels
-          const { data: prs } = await github.rest.pulls.list({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            state: 'open'
-          });
-          
-          for (const pr of prs) {
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number
-            });
-            
-            const hasLgtm = labels.some(label => label.name === 'lgtm');
-            const hasApproved = labels.some(label => label.name === 'approved');
-            
-            if (hasLgtm && hasApproved && pr.mergeable && !pr.draft) {
-              // Check status checks
-              const { data: statusChecks } = await github.rest.repos.getCombinedStatusForRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: pr.head.sha
-              });
-              
-              const { data: checkRuns } = await github.rest.checks.listForRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: pr.head.sha
-              });
-              
-              const allStatusesPass = statusChecks.state === 'success' || statusChecks.statuses.length === 0;
-              const allChecksPass = checkRuns.check_runs.every(check => 
-                check.conclusion === 'success' || check.conclusion === 'neutral' || check.conclusion === 'skipped'
-              );
-              
-              if (allStatusesPass && allChecksPass) {
-                try {
-                  await github.rest.pulls.merge({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pull_number: pr.number,
-                    commit_title: `${pr.title} (#${pr.number})`,
-                    merge_method: 'squash'
-                  });
-                  
-                  console.log(`Successfully merged PR #${pr.number}`);
-                } catch (error) {
-                  console.log(`Failed to merge PR #${pr.number}: ${error.message}`);
-                }
-              }
-            }
-          }
+      - uses: jpmcb/prow-github-actions@v2
+        with:
+          jobs: lgtm
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          merge-method: squash

--- a/TEST.md
+++ b/TEST.md
@@ -1,0 +1,7 @@
+# Test PR
+
+This is a no-op test PR to verify the /lgtm and /approve automation works correctly.
+
+- Test comment commands
+- Verify label addition
+- Check auto-merge functionality


### PR DESCRIPTION
Replace custom GitHub Actions script with prow-github-actions for cleaner implementation.

Auto-merge now triggers immediately when:
- `lgtm` label is applied
- CI completes (status or check_suite events)

Uses prow-github-actions v2 with squash merge method.